### PR TITLE
Remove Connection Interrupted from scoreboard.

### DIFF
--- a/code/cgame/cg_superhud_element_ng.c
+++ b/code/cgame/cg_superhud_element_ng.c
@@ -48,6 +48,10 @@ void CG_SHUDElementNGRoutine(void* context)
 	int     color = 0;
 	float   vscale;
 
+	if (cg.snap->ps.pm_type == PM_INTERMISSION) {
+        return;
+    }
+
 	ax = element->config.rect.value[0];
 	ay = element->config.rect.value[1];
 	aw = element->config.rect.value[2];


### PR DESCRIPTION
When the map ends, a lot of times you'll see a "Connection Interrupted" message drawing in red right below the scoreboard. This removes that.