### PR TITLE
fixed a bug where crosshair names would print in black long after the…

### DIFF
--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -1872,8 +1872,6 @@ void CG_DrawCrosshairNames(void)
 	color = CG_FadeColor(cg.crosshairClientTime, 1000);
 	if ( !color )
 	{
-		// no valid color, clear the crosshair client number
-		cg.crosshairClientNum = -1;
 		return;
 	}
 	name = cgs.clientinfo[ cg.crosshairClientNum ].name;

--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -1870,6 +1870,12 @@ void CG_DrawCrosshairNames(void)
 	}
 
 	color = CG_FadeColor(cg.crosshairClientTime, 1000);
+	if ( !color )
+	{
+		// no valid color, clear the crosshair client number
+		cg.crosshairClientNum = -1;
+		return;
+	}
 	name = cgs.clientinfo[ cg.crosshairClientNum ].name;
 	CG_DrawBigString(SCREEN_WIDTH / 2.0f, 170, name, 0.5f * color[3], DS_HCENTER | DS_SHADOW, 0);
 }


### PR DESCRIPTION
When cg_shud 0 and cg_enableOSPHUD 0 if you move your crosshair over another player, their name will draw to the screen. The problem is, after the color fade transition, the name will remain in black text for a while.  This fixes that.