### PR TITLE
Fixed Teamoverlay

### DIFF
--- a/assets/hud/default.cfg
+++ b/assets/hud/default.cfg
@@ -133,14 +133,14 @@ PlayerSpeed { rect 340 466 0 0; font sansman; textalign R; fontsize 9 12; color 
 
 # Teamoverlay
 !DEFAULT { font sansman; textalign L; fontsize 6 10; bgcolor 0.75 0.75 0.75 0.25; fill; monospace; alignh L; alignv C; fadedelay 0; time 0; color 1 1 1 1; }
-Team1 { rect 4 380 0 10; }
-Team2 { rect 4 390 0 10; }
-Team3 { rect 4 400 0 10; }
-Team4 { rect 4 410 0 10; }
-Team5 { rect 4 420 0 10; }
-Team6 { rect 4 430 0 10; }
-Team7 { rect 4 440 0 10; }
-Team8 { rect 4 450 0 10; }
+Team1             { rect 4 380 0 10; }
+Team2             { rect 4 390 0 10; }
+Team3             { rect 4 400 0 10; }
+Team4             { rect 4 410 0 10; }
+Team5             { rect 4 420 0 10; }
+Team6             { rect 4 430 0 10; }
+Team7             { rect 4 440 0 10; }
+Team8             { rect 4 450 0 10; }
 
 # Medals
 !default{ alignh C; direction L; fadedelay 1800; time 200; fade 1 1 1 0; }

--- a/assets/hud/default.cfg
+++ b/assets/hud/default.cfg
@@ -132,15 +132,15 @@ ItemPickupIcon { rect 314 330 12 16; }
 PlayerSpeed { rect 340 466 0 0; font sansman; textalign R; fontsize 9 12; color 1 1 1 0.2; textstyle 0; }
 
 # Teamoverlay
-!DEFAULT { font sansman; textalign L; fontsize 6 10; bgcolor 0.75 0.75 0.75 0.25; fill; monospace; alignh L; alignv C; fadedelay 0; time 0; color 1 1 1 1; }
-Team1             { rect 4 380 0 10; }
-Team2             { rect 4 390 0 10; }
-Team3             { rect 4 400 0 10; }
-Team4             { rect 4 410 0 10; }
-Team5             { rect 4 420 0 10; }
-Team6             { rect 4 430 0 10; }
-Team7             { rect 4 440 0 10; }
-Team8             { rect 4 450 0 10; }
+!DEFAULT 		{ font sansman; textalign L; fontsize 6 10; bgcolor 0.75 0.75 0.75 0.25; fill; monospace; alignh L; alignv C; fadedelay 0; time 0; color 1 1 1 1; }
+Team8 			{ rect 4 340 0 10; }
+Team7 			{ rect 4 350 0 10; }
+Team6 			{ rect 4 360 0 10; }
+Team5 			{ rect 4 370 0 10; }
+Team4 			{ rect 4 380 0 10; }
+Team3 			{ rect 4 390 0 10; }
+Team2 			{ rect 4 400 0 10; }
+Team1 			{ rect 4 410 0 10; }
 
 # Medals
 !default{ alignh C; direction L; fadedelay 1800; time 200; fade 1 1 1 0; }


### PR DESCRIPTION
Team overlay on the default HUD was drawing from the top down instead of the bottom up when positioned at the bottom left.  This left a strange gap, plus the positioning was off when you had 8 players and it would overlap other elements on the HUD.