### PR TITLE
fixed cg_gibs

### DIFF
--- a/code/cgame/cg_effects.c
+++ b/code/cgame/cg_effects.c
@@ -428,7 +428,7 @@ void CG_GibPlayer(vec3_t playerOrigin)
 {
 	vec3_t  origin, velocity;
 
-	if (!com_blood.integer)
+	if (!com_blood.integer || !cg_gibs.integer)
 	{
 		return;
 	}


### PR DESCRIPTION
Gibs would still display when cg_gibs was set to 0.  I'm not sure that com_blood belongs here, but I don't think there is currently a way to disable blood on gib explosions anyway without it so it might be necessary.