### PR TITLE
fixed score display for freeze and CTF since they use capturelimit

### DIFF
--- a/code/cgame/cg_superhud_element_score.c
+++ b/code/cgame/cg_superhud_element_score.c
@@ -60,7 +60,12 @@ void* CG_SHUDElementScoreMAXCreate(const superhudConfig_t* config)
 
 static qboolean CG_SHUDScoresGetMax(int* scores)
 {
-	*scores = cgs.fraglimit;
+	if (cgs.gametype == GT_CTF || cgs.osp.gameTypeFreeze) {
+        *scores = cgs.capturelimit;
+    } else {
+        *scores = cgs.fraglimit;
+    }
+	
 	return *scores > 0;
 }
 

--- a/code/cgame/cg_superhud_element_score.c
+++ b/code/cgame/cg_superhud_element_score.c
@@ -60,7 +60,7 @@ void* CG_SHUDElementScoreMAXCreate(const superhudConfig_t* config)
 
 static qboolean CG_SHUDScoresGetMax(int* scores)
 {
-	if (cgs.gametype == GT_CTF || cgs.osp.gameTypeFreeze) {
+	if (cgs.gametype == GT_CTF) {
         *scores = cgs.capturelimit;
     } else {
         *scores = cgs.fraglimit;


### PR DESCRIPTION
Wrong score limit displayed at the top, because freeze tag and CTF use capturelimit rathr than fraglimit. This fixes that.