### PR TITLE
Fix linux .so build

### DIFF
--- a/build/linux/Makefile
+++ b/build/linux/Makefile
@@ -333,6 +333,9 @@ makedirs:
 
 CGOBJ_ = \
   $(B)/$(MOD)/cgame/cg_main.o \
+  $(B)/$(MOD)/cgame/cg_cvardescriptions.o \
+  $(B)/$(MOD)/cgame/cg_crosshair.o \
+  $(B)/$(MOD)/cgame/cg_chatfilter.o \
   $(B)/$(MOD)/cgame/cg_consolecmds.o \
   $(B)/$(MOD)/cgame/cg_customloc.o \
   $(B)/$(MOD)/cgame/cg_draw.o \
@@ -368,12 +371,15 @@ CGOBJ_ = \
   $(B)/$(MOD)/cgame/cg_superhud_element_fps.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_fragmessage.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_gametime.o \
+  $(B)/$(MOD)/cgame/cg_superhud_element_gametype.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_itempickup.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_itempickupicon.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_localtime.o \
+  $(B)/$(MOD)/cgame/cg_superhud_element_location.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_name.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_ng.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_ngp.o \
+  $(B)/$(MOD)/cgame/cg_superhud_element_obituaries.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_powerup.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_pred.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_rankmessage.o \
@@ -395,6 +401,7 @@ CGOBJ_ = \
   $(B)/$(MOD)/cgame/cg_superhud_element_team.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_teamcount.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_vmw.o \
+  $(B)/$(MOD)/cgame/cg_superhud_element_warmupinfo.o \
   $(B)/$(MOD)/cgame/cg_superhud_element_weaponlist.o \
   $(B)/$(MOD)/cgame/cg_superhud_private.o \
   $(B)/$(MOD)/cgame/cg_superhud_util.o \
@@ -404,6 +411,7 @@ CGOBJ_ = \
   $(B)/$(MOD)/game/bg_pmove.o \
   $(B)/$(MOD)/game/bg_slidemove.o \
   \
+  $(B)/$(MOD)/qcommon/l_crc.o \
   $(B)/$(MOD)/qcommon/common.o \
   $(B)/$(MOD)/qcommon/q_math.o \
   $(B)/$(MOD)/qcommon/q_shared.o 

--- a/code/cgame/cg_cvardescriptions.c
+++ b/code/cgame/cg_cvardescriptions.c
@@ -1,3 +1,5 @@
+#include "cg_local.h"
+
 typedef struct {
     const char* cvarName;
     const char* description;

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1958,6 +1958,16 @@ void CG_RegisterCvarDescriptions(void);
 // print message on the local console
 void        trap_Print(const char* fmt);
 
+#ifndef Q3_VM
+
+// Special functions to call from native VM. Fixes segmentation fault in Q3E.
+
+// Use them as wrappers, pass acquired function address to `cmd` to make actual call.
+int     trap_CG_GetValue_Q3E(int cmd, char* value, int valueSize, const char* key);
+int     trap_CG_SetDescription_Q3E(int cmd, const char* name, const char* description);
+
+#endif
+
 // abort the game
 void        trap_Error(const char* fmt);
 

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -38,6 +38,7 @@ This is the only way control passes into the module.
 This must be the very first function compiled into the .q3vm file
 ================
 */
+Q_EXPORT
 int vmMain(int command, int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11)
 {
 

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -2015,6 +2015,18 @@ static void trap_Cvar_SetDescription_local(const char *name, const char *descrip
 typedef void (setCvarDescription_t)(const char *name, const char *description);
 typedef qboolean (trap_GetValue_t)( char *value, int valueSize, const char *key );
 
+
+// [meta]:
+// I have splitted this func for VM and non-VM ( native code ), 'cause
+// under native build ( non-vm ) it causes segmentation fault. The
+// reason is `addr` var: it's used as function address, but function
+// address is valid only for VM build, so it crashes. Call through
+// syscall instead should handle it correctly.
+
+// The code differs too much to place it in one function.
+
+#ifdef Q3_VM
+
 void CG_SetCvarDescription(const char *name, const char *description)
 {
 	static setCvarDescription_t* setDescription = NULL;
@@ -2030,16 +2042,17 @@ void CG_SetCvarDescription(const char *name, const char *description)
 
 		if ( value[0] ) {
 			addr = atoi(value);
-#ifdef Q3_VM
-			addr = ~addr; 
-#endif
+
+			addr = ~addr;
+
 			trap_GetValue = (trap_GetValue_t*)(addr);
-			if ( trap_GetValue( value, sizeof( value ), "trap_Cvar_SetDescription_Q3E" ) ) 
+
+			if ( trap_GetValue( value, sizeof( value ), "trap_Cvar_SetDescription_Q3E" ) )
 			{
 				addr = atoi(value);
-#ifdef Q3_VM
-			addr = ~addr; 
-#endif
+
+				addr = ~addr;
+
 				setDescription = (setCvarDescription_t*)addr;
 			}
 		}
@@ -2048,3 +2061,35 @@ void CG_SetCvarDescription(const char *name, const char *description)
 	setDescription(name, description);
 }
 
+#else
+
+void CG_SetCvarDescription(const char *name, const char *description)
+{
+	static int setDescriptionFuncId = 0;
+
+	if (!setDescriptionFuncId)
+	{
+		int getValueFuncId;
+		char  value[MAX_CVAR_VALUE_STRING];
+
+		// -1 treats as dummy function
+		setDescriptionFuncId = -1;
+
+		trap_Cvar_VariableStringBuffer( "//trap_GetValue", value, sizeof( value ) );
+
+		if ( value[0] ) {
+			getValueFuncId = atoi(value);
+
+			if ( trap_CG_GetValue_Q3E( getValueFuncId, value, sizeof( value ), "trap_Cvar_SetDescription_Q3E" ) ) 
+			{
+				setDescriptionFuncId = atoi(value);
+			}
+		}
+	}
+
+	if (setDescriptionFuncId == -1) return;
+
+	trap_CG_SetDescription_Q3E((int)setDescriptionFuncId, name, description);
+}
+
+#endif

--- a/code/cgame/cg_syscalls.c
+++ b/code/cgame/cg_syscalls.c
@@ -45,6 +45,20 @@ int PASSFLOAT(float x)
 	return *(int*)&floatTemp;
 }
 
+#ifndef Q3_VM
+
+// Wrappers for native builds
+
+int     trap_CG_GetValue_Q3E(int cmd, char* value, int valueSize, const char* key) {
+    return syscall(cmd, value, valueSize, key);
+}
+
+int     trap_CG_SetDescription_Q3E(int cmd, const char* name, const char* description) {
+    return syscall(cmd, name, description);
+}
+
+#endif
+
 void    trap_Print(const char* fmt)
 {
 	syscall(CG_PRINT, fmt);

--- a/code/cgame/cg_syscalls.c
+++ b/code/cgame/cg_syscalls.c
@@ -31,6 +31,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 static int (QDECL* syscall)(int arg, ...) = (int (QDECL*)(int, ...)) - 1;
 
 
+Q_EXPORT
 void dllEntry(int (QDECL*  syscallptr)(int arg, ...))
 {
 	syscall = syscallptr;

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -59,6 +59,12 @@ extern "C" {
 #pragma warning(disable : 4220)     // varargs matches remaining parameters
 #endif
 
+#if ((__GNUC__ >= 3) && (!__EMX__) && (!sun))
+#define Q_EXPORT __attribute__((visibility("default")))
+#else
+#define Q_EXPORT
+#endif
+
 /**********************************************************************
   VM Considerations
 


### PR DESCRIPTION
Fixes `Makefile` and game code, so it builds as linux native library, without breaking `qvm` build.
- `ioquake3` under `GCC` works fine
- `Q3E` seemed to have segfault caused by `CG_SetCvarDescription`, but now fixed.

> `qvm` and `native` builds both work fine on both clients.