### PR TITLE
Promode and VQ3 Movement predict fix

### DIFF
--- a/code/cgame/cg_ospconfig.c
+++ b/code/cgame/cg_ospconfig.c
@@ -63,7 +63,7 @@ void CG_OSPSetMode(int value)
 	modePredictionKoeff2               = OSP_SET_MODE_VARIANT(value, 0, 0, 150);//-V583
 	modePromode_pm_airaccelerate_2     = OSP_SET_MODE_VARIANT(value, 1, 1, 70);//-V583
 	modeWishspeedLimit                 = OSP_SET_MODE_VARIANT(value, 400, 400, 30);//-V583
-	pm_accelerate                      = OSP_SET_MODE_VARIANT(value, 10, 10, 16);//-V583
+	pm_accelerate                      = OSP_SET_MODE_VARIANT(value, 10, 10, 15);//-V583
 	modeSwimScale1                     = OSP_SET_MODE_VARIANT(value, 0.5f, 0.54f, 0.54f);//-V583
 	modeSwimScale2                     = OSP_SET_MODE_VARIANT(value, 0.7f, 0.585f, 0.585f);//-V583
 	pm_waterfriction                   = OSP_SET_MODE_VARIANT(value, 1.0f, 0.5f, 0.5f);//-V583

--- a/code/game/bg_slidemove.c
+++ b/code/game/bg_slidemove.c
@@ -317,8 +317,9 @@ void PM_StepSlideMove(qboolean gravity)
 	VectorCopy(start_o, up);
 	up[2] += STEPSIZE;
 
-	// test the player position if they were a stepheight higher
-	pm->trace(&trace, start_o, pm->mins, pm->maxs, up, pm->ps->clientNum, pm->tracemask);
+	/* OSP 1.03: point test at +STEPSIZE (start==end). Sweep start_o->up is ioquake3;
+	   a ceiling makes fraction<1 / not allsolid and would copy into the brush. */
+	pm->trace(&trace, up, pm->mins, pm->maxs, up, pm->ps->clientNum, pm->tracemask);
 	if (trace.allsolid)
 	{
 		if (pm->debugLevel)
@@ -328,9 +329,8 @@ void PM_StepSlideMove(qboolean gravity)
 		return;     // can't step up
 	}
 
-	stepSize = trace.endpos[2] - start_o[2];
-	// try slidemove from this position
-	VectorCopy(trace.endpos, pm->ps->origin);
+	stepSize = STEPSIZE;
+	VectorCopy(up, pm->ps->origin);
 	VectorCopy(start_v, pm->ps->velocity);
 
 	PM_SlideMove(gravity);
@@ -348,11 +348,9 @@ void PM_StepSlideMove(qboolean gravity)
 		if (pm->ps->stats[STAT_OSP_10])
 		{
 			PM_ClipVelocityOSP(pm->ps->velocity, trace.plane.normal, pm->ps->velocity, OVERCLIP);
+			return;
 		}
-		else
-		{
-			PM_ClipVelocity(pm->ps->velocity, trace.plane.normal, pm->ps->velocity, OVERCLIP);
-		}
+		PM_ClipVelocity(pm->ps->velocity, trace.plane.normal, pm->ps->velocity, OVERCLIP);
 	}
 
 #if 0


### PR DESCRIPTION
Исправляет ошибку предикта при server_promode 1 при движении на земле. 
Исправляет ошибку предикта при VQ3/Promode при ударе об потолок (наклонный).

Основано на оригинальном коде OSP 1.03 (Спасибо BigIndian) 
Протестировано на OSP Server 1.03 при cg_showMiss 1.
После фикса ошибки пропали